### PR TITLE
Feature/discord api apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@
 ## Back-End
 
 - NestJS [10.3.2]
+- Discord.js [14.14.1]
+
+# 참고 URL
+
+1. Discord.js
+   - https://discord.js.org/docs/packages/discord.js/14.14.1

--- a/backend/src/discord/discord.client.service.ts
+++ b/backend/src/discord/discord.client.service.ts
@@ -39,11 +39,13 @@ export class DiscordClientService {
 
     // 봇 준비 완료 이벤트
     this.client.on('ready', () => {
-      this.logger.log(`Logged in as ${this.client.user.tag}!`);
+      this.logger.log(`### [ Logged in as ${this.client.user.tag}! ] ###`);
       this.isReady = true;
       this.getGuilds();
       // 컨텍스트 메뉴 추가
       this.createContextMenu();
+      // 컨테스트 메뉴 이벤트 리스너 등록
+      this.onContextMenu();
     });
     this.client.on('error', (error) => {
       this.logger.error('Discord Error', error);
@@ -82,13 +84,23 @@ export class DiscordClientService {
     }
     await guild.commands.set([
       {
-        name: '사용자 정보',
-        type: ApplicationCommandType.User,
+        // 독일어로 번역
+        name: 'Translate to German',
+        type: ApplicationCommandType.Message,
       },
-    ]);
-    await guild.commands.set([
       {
-        name: '메시지 정보',
+        // 일본어로 번역
+        name: 'Translate to Japanese',
+        type: ApplicationCommandType.Message,
+      },
+      {
+        // 영어로 번역
+        name: 'Translate to English',
+        type: ApplicationCommandType.Message,
+      },
+      {
+        // 한글로 번역
+        name: 'Translate to Korean',
         type: ApplicationCommandType.Message,
       },
     ]);
@@ -96,7 +108,43 @@ export class DiscordClientService {
   // 컨텍스트메뉴 이벤트 리스너
   onContextMenu() {
     this.client.on('interactionCreate', async (interaction) => {
-      console.log(interaction);
+      if (!interaction.isMessageContextMenuCommand()) return;
+      // 디스코드 채널로 메시지 전송
+      const locale = interaction.locale;
+
+      // 선택한 커맨드
+      const targetLanguage = this.getTargetLanguage(interaction.commandName);
+      if (locale === targetLanguage) return;
+
+      // 선택한 메시지 정보
+      const message = await interaction.channel.messages.fetch(
+        interaction.targetId,
+      );
+
+      // 입력 메시지
+      const content = message.content;
+
+      // todo 번역 API 호출
+      interaction.reply(
+        `사용자의 언어는 ${locale}이고, 번역할 언어는 ${targetLanguage}입니다.
+        입력한 메시지는 [ ${content} ] 입니다.`,
+      );
     });
+  }
+
+  // 선택한 번역 언어 코드
+  private getTargetLanguage(command: string) {
+    switch (command) {
+      case 'Translate to German':
+        return 'de';
+      case 'Translate to Japanese':
+        return 'ja';
+      case 'Translate to English':
+        return 'en';
+      case 'Translate to Korean':
+        return 'ko';
+      default:
+        return 'en';
+    }
   }
 }

--- a/backend/src/discord/discord.client.service.ts
+++ b/backend/src/discord/discord.client.service.ts
@@ -6,11 +6,12 @@ import { Client, GatewayIntentBits, Guild } from 'discord.js';
 @Injectable()
 export class DiscordClientService {
   private readonly logger = new Logger(DiscordClientService.name);
-
   // 봇 클라이언트
   private client: Client;
   // 봇 등록된 서버 목록
   private guildListMap = new Map<string, Guild>();
+  // 봇 준비 완료 여부
+  private isReady = false;
 
   constructor(
     @Inject(discordConfig.KEY) private config: ConfigType<typeof discordConfig>,
@@ -34,7 +35,11 @@ export class DiscordClientService {
     // 봇 준비 완료 이벤트
     this.client.on('ready', () => {
       this.logger.log(`Logged in as ${this.client.user.tag}!`);
+      this.isReady = true;
       this.getGuilds();
+    });
+    this.client.on('error', (error) => {
+      this.logger.error('Discord Error', error);
     });
 
     // 봇 로그인
@@ -54,6 +59,10 @@ export class DiscordClientService {
 
   get guildList() {
     return this.guildListMap;
+  }
+
+  get ready() {
+    return this.isReady;
   }
 
   getGuildInfo(guildId: string) {

--- a/backend/src/discord/discord.client.service.ts
+++ b/backend/src/discord/discord.client.service.ts
@@ -1,7 +1,12 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import discordConfig from 'src/config/conf/discord.config';
-import { Client, GatewayIntentBits, Guild } from 'discord.js';
+import {
+  ApplicationCommandType,
+  Client,
+  GatewayIntentBits,
+  Guild,
+} from 'discord.js';
 
 @Injectable()
 export class DiscordClientService {
@@ -37,6 +42,8 @@ export class DiscordClientService {
       this.logger.log(`Logged in as ${this.client.user.tag}!`);
       this.isReady = true;
       this.getGuilds();
+      // 컨텍스트 메뉴 추가
+      this.createContextMenu();
     });
     this.client.on('error', (error) => {
       this.logger.error('Discord Error', error);
@@ -57,15 +64,39 @@ export class DiscordClientService {
     return this.client;
   }
 
-  get guildList() {
-    return this.guildListMap;
-  }
-
   get ready() {
     return this.isReady;
   }
 
   getGuildInfo(guildId: string) {
     return this.guildListMap.get(guildId);
+  }
+
+  // 컨텍스트 메뉴 추가
+  private async createContextMenu() {
+    const guildId = '1098235615574769706';
+    const guild = this.getGuildInfo(guildId);
+    if (!guild) {
+      this.logger.error('Guild not found');
+      return;
+    }
+    await guild.commands.set([
+      {
+        name: '사용자 정보',
+        type: ApplicationCommandType.User,
+      },
+    ]);
+    await guild.commands.set([
+      {
+        name: '메시지 정보',
+        type: ApplicationCommandType.Message,
+      },
+    ]);
+  }
+  // 컨텍스트메뉴 이벤트 리스너
+  onContextMenu() {
+    this.client.on('interactionCreate', async (interaction) => {
+      console.log(interaction);
+    });
   }
 }


### PR DESCRIPTION
1. 디스코드 컨텍스트 메뉴 추가
 - 번역할 언어 선택 메뉴 4개 
 - 사용자 위치 국가 코드 기준으로 번역할 언어 선택하게 할 예정
 - 번역 가능 언어는 한국어, 영어, 일본어, 독일어
2. 파파고API로 전달할 정보까지만 맵핑 해둠.

파파고 API 붙여야하고, 추후에 소스코드 깔끔하게 리팩토리 해야함